### PR TITLE
Add missing socket.io-client import

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,18 @@
     "start": "node server.js",
     "dev": "node server.js"
   },
-  "keywords": ["p2p", "chat", "webrtc", "peer-to-peer"],
+  "keywords": [
+    "p2p",
+    "chat",
+    "webrtc",
+    "peer-to-peer"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {
     "express": "^4.18.2",
     "socket.io": "^4.7.2",
+    "socket.io-client": "^4.8.1",
     "uuid": "^9.0.0"
   }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -1,3 +1,4 @@
+const { io } = require("socket.io-client");
 class FlashDropApp {
     constructor() {
         this.socket = null;


### PR DESCRIPTION
**Summary:** This PR adds a missing import statement for socket.io-client, which is required to initialize the io() function.

**Details:**
Without the following line: 
`const { io } = require("socket.io-client");`
the io() function is undefined, causing an error when trying to establish a Socket.IO connection.

This fix ensures that the client can properly connect to the Socket.IO server.